### PR TITLE
rework icon providers order to override other plugins icons (e.g. Docker)

### DIFF
--- a/resources/META-INF/angular2.xml
+++ b/resources/META-INF/angular2.xml
@@ -2,7 +2,7 @@
 	<extensions defaultExtensionNs="com.intellij">
 		<iconProvider
 				id="angular2IconProvider"
-				order="first"
+				order="after genericIconProvider"
 				implementation="lermitage.intellij.extra.icons.providers.Angular2IconProvider"/>
 	</extensions>
 </idea-plugin>

--- a/resources/META-INF/javascript.xml
+++ b/resources/META-INF/javascript.xml
@@ -2,7 +2,7 @@
 	<extensions defaultExtensionNs="com.intellij">
 		<iconProvider
 				id="javascriptIconProvider"
-				order="first"
+				order="after genericIconProvider"
 				implementation="lermitage.intellij.extra.icons.providers.JavascriptIconProvider"/>
 	</extensions>
 </idea-plugin>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -32,7 +32,7 @@
     <!-- Add your extensions here -->
     <iconProvider
 		    id="genericIconProvider"
-		    order="last"
+		    order="first"
 		    implementation="lermitage.intellij.extra.icons.ExtraIconProvider"/>
   </extensions>
 

--- a/resources/META-INF/sass.xml
+++ b/resources/META-INF/sass.xml
@@ -2,7 +2,7 @@
 	<extensions defaultExtensionNs="com.intellij">
 		<iconProvider
 				id="sassIconProvider"
-				order="before genericIconProvider"
+				order="after angular2IconProvider"
 				implementation="lermitage.intellij.extra.icons.providers.SassIconProvider"/>
 	</extensions>
 </idea-plugin>


### PR DESCRIPTION
If `genericIconProvider` is not in the first providers, it cannot override some icons, like `docker-compose` files.