### PR TITLE
fix-babel_regex > ide201

### DIFF
--- a/src/main/java/lermitage/intellij/extra/icons/ExtraIconProvider.java
+++ b/src/main/java/lermitage/intellij/extra/icons/ExtraIconProvider.java
@@ -152,6 +152,10 @@ public class ExtraIconProvider extends BaseIconProvider implements DumbAware {
                 .regex(".*/db/changelog/.*\\.(sql|xml)"),
             ofFile("mockk", "/extra-icons/mockk.svg", "Mockk: io/mockk/settings.properties")
                 .regex(".*/io/mockk/settings\\.properties"),
+            ofFile("babel", "/extra-icons/babel_alt.svg", "Babel: babel.config.[json|js|cjs|mjs]|.babelrc.[json|js|cjs|mjs]|.babelrc")
+                .regex(".*/babel\\.config\\.(?:js(?:on)?|[cm]js)|\\.babelrc(?:\\.(?:js(?:on)?|[cm]js))?"),
+            ofFile("babel_alt", "/extra-icons/babel_alt2.svg", "(alternative) Babel: babel.config.[json|js|cjs|mjs]|.babelrc.[json|js|cjs|mjs]|.babelrc")
+                .regex(".*/babel\\.config\\.(?:js(?:on)?|[cm]js)|\\.babelrc(?:\\.(?:js(?:on)?|[cm]js))?"),
 
             //
             // file plus its containing folder
@@ -212,10 +216,6 @@ public class ExtraIconProvider extends BaseIconProvider implements DumbAware {
                 .eq("gradle-wrapper.jar", "gradle-wrapper.properties"),
             ofFile("mvnw_linux", "/extra-icons/mvnw.svg", "Maven: mvnw")
                 .eq("mvnw"),
-            ofFile("babel", "/extra-icons/babel_alt.svg", "Babel: babel.config.json")
-                 .eq("babel.config.json"),
-            ofFile("babel_alt", "/extra-icons/babel_alt2.svg", "Babel: babel.config.json (alternative)")
-                 .eq("babel.config.json"),
             ofFile("berksfile", "/extra-icons/berkshelf.png", "Berkshelf: berksfile")
                 .eq("berksfile"),
             ofFile("berksfilelock", "/extra-icons/berkshelflock.png", "Berkshelf: berksfile.lock")


### PR DESCRIPTION
Hi :) 
I realized that I had made a mistake while opening an old project with a babel configuration file in `.js`.

According to [the doc](https://babeljs.io/docs/en/config-files#supported-file-extensions) the following pattern is a possible config file for babel :
```
babel.config.json 
babel.config.js
babel.config.cjs
babel.config.mjs
.babelrc.json
.babelrc 
.babelrc.js
.babelrc.cjs
.babelrc.mjs
```
I have update the code with a regex match.

[Test of the regex in regex101.](https://regex101.com/r/3uq64y/1)