### PR TITLE
Update storybook regex to fix false positive matches

### DIFF
--- a/src/main/java/lermitage/intellij/extra/icons/ExtraIconProvider.java
+++ b/src/main/java/lermitage/intellij/extra/icons/ExtraIconProvider.java
@@ -548,7 +548,7 @@ public class ExtraIconProvider extends BaseIconProvider implements DumbAware {
                 .eq("screwdriver.yaml"),
             ofFile("stacksmith", "/extra-icons/stacksmith.svg", "Bitnami Stacksmith: stackerfile.yml")
                 .eq("stackerfile.yml"),
-            ofFile("storybook", "/extra-icons/storybook.svg", "Storybook: *stor(y|ies).(js|jsx|ts|tsx|mdx)")
+            ofFile("storybook", "/extra-icons/storybook.svg", "Storybook: *.stor(y|ies).(js|jsx|ts|tsx|mdx)")
                 .regex(".*\\.stor(y|ies)\\.(js|jsx|ts|tsx|mdx)$"),
             ofFile("svgo", "/extra-icons/svgo.svg", "SVGO: svgo(.yml,.yaml)")
                 .eq("svgo").end(YML),

--- a/src/main/java/lermitage/intellij/extra/icons/ExtraIconProvider.java
+++ b/src/main/java/lermitage/intellij/extra/icons/ExtraIconProvider.java
@@ -549,7 +549,7 @@ public class ExtraIconProvider extends BaseIconProvider implements DumbAware {
             ofFile("stacksmith", "/extra-icons/stacksmith.svg", "Bitnami Stacksmith: stackerfile.yml")
                 .eq("stackerfile.yml"),
             ofFile("storybook", "/extra-icons/storybook.svg", "Storybook: *stor(y|ies).(js|jsx|ts|tsx|mdx)")
-                .regex(".*stor(y|ies)\\.(js|jsx|ts|tsx|mdx)$"),
+                .regex(".*\\.stor(y|ies)\\.(js|jsx|ts|tsx|mdx)$"),
             ofFile("svgo", "/extra-icons/svgo.svg", "SVGO: svgo(.yml,.yaml)")
                 .eq("svgo").end(YML),
             ofFile("svgo2", "/extra-icons/svgo.svg", "SVGO: svgo.config.js")


### PR DESCRIPTION
Currently the storybook pattern is matching, for example, `history.js`. This PR will fix that.

I haven't removed the initial `.*` as I only wanted to add the bare minimum required changes. Happy to make that update also, if desired

Fixes #71 