### PR TITLE
fix typo in ext_exe description

### DIFF
--- a/src/main/java/lermitage/intellij/extra/icons/ExtraIconProvider.java
+++ b/src/main/java/lermitage/intellij/extra/icons/ExtraIconProvider.java
@@ -720,7 +720,7 @@ public class ExtraIconProvider extends BaseIconProvider implements DumbAware {
                 .end(".drawio", ".dio"),
             ofFile("ext_epub", "/extra-icons/epub.svg", "Epub: *.epub, *.mobi, *.azw, *.azw3")
                 .end(".epub", ".mobi", ".azw", ".azw3"),
-            ofFile("ext_exe", "/extra-icons/msexe.png", "MS Winows: *.exe")
+            ofFile("ext_exe", "/extra-icons/msexe.png", "Windows executable: *.exe")
                 .end(".exe"),
             ofFile("ext_form", "/extra-icons/form.svg", "Form (e.g. IntelliJ Swing xml form): *.form")
                 .end(".form"),


### PR DESCRIPTION
`MS Winows` containes a typo.
Also I suppose `ext_exe` description should be conform with `ext_dll*`: `Windows DLL` and `Windows executable`